### PR TITLE
Update slides skill for table height + autofit

### DIFF
--- a/plugins/google-slides-toolforest/references/tables-and-formatting.md
+++ b/plugins/google-slides-toolforest/references/tables-and-formatting.md
@@ -2,7 +2,8 @@ Read this file when creating tables or text-heavy slides. The multi-run techniqu
 ## Table Creation
 - Use create_table with values for initial content, headerFillColorHex for styled headers
 - alternateRowColorHex adds automatic row striping
-- Table dimensions in get_slide_content_elements may show defaults (3,000,000 × 3,000,000) even when created differently — this is a reporting quirk, not a layout bug
+- Set autofit: true to automatically shrink header and body font sizes to fit within the specified table height (assumes Arial metrics). Set minFontSize to control the floor (default 8pt). Check autofitApplied and scaleFactor in the response — values below ~0.7 mean the table is too dense for the space.
+- get_slide_content_elements returns estimatedContentHeight and estimatedOverflow for tables, plus an autofit field showing whether autofit was applied and the scale factor used
 
 ## Multi-Run Text Formatting — The Key to Visual Hierarchy
 The add_text_box tool supports multiple runs per paragraph, each with independent font size, color, bold/italic, and font family. Always use this to create proper hierarchy. Never default to a single font size and color for an entire text box.

--- a/plugins/google-slides-toolforest/scripts/verify_slide.md
+++ b/plugins/google-slides-toolforest/scripts/verify_slide.md
@@ -5,10 +5,10 @@ Run this checklist after building EVERY slide. Call get_slide_content_elements a
 - Sufficient margins: Content should be ≥ 457,200 EMU (0.5") from slide edges.
 - Sufficient gaps: At least 150,000 EMU (~0.16") between elements; 228,600 EMU (~0.25") is better.
 
-## Text Overflow Checks
-- Check estimatedOverflow: false on all text boxes.
-- Compare estimatedContentHeight to the text box’s actual height.
-- If autofit was used, check scaleFactor — values below ~0.7 mean the box is too small.
+## Text and Table Overflow Checks
+- Check estimatedOverflow: false on all text boxes and tables.
+- Compare estimatedContentHeight to the element’s actual height.
+- If autofit was used (text boxes or tables), check scaleFactor — values below ~0.7 mean the element is too small for the content.
 
 ## Formatting Quality Checks
 - Text hierarchy is visible: Can you immediately distinguish headings from body text from captions?
@@ -18,7 +18,8 @@ Run this checklist after building EVERY slide. Call get_slide_content_elements a
 - Colors create contrast: Accent colors for emphasis, muted colors for secondary info, correct text color for the background.
 
 ## Common Issues to Watch For
-- autofit reported as type: "NONE" on read-back even when applied during creation — this is a known reporting issue (GitHub #611), not a bug
+- Text box autofit reported as googleAutofitType: "NONE" on read-back even when applied during creation — this is expected because Toolforest pre-scales font sizes at creation time
+- Table autofit is reported correctly via the autofit field (autofitApplied, scaleFactor) stored as presentation metadata
 - Default placeholder elements (i0, i1) not deleted on first slide — these overlap custom content
 - z-order: get_slide_content_elements returns elements in z-order, later elements render on top — verify layering is correct
 - Master element injection via set_master_elements may add decorative shapes to every new slide — account for these in layout


### PR DESCRIPTION
## Summary
Updates the google-slides-toolforest skill to reflect new table features shipped in toolforest_tools PRs #680 and #682:

- **tables-and-formatting.md**: Document `autofit` and `minFontSize` params on `create_table`. Remove outdated note about table dimensions showing defaults (now fixed with HarfBuzz measurement).
- **verify_slide.md**: Include tables in overflow checks (they now return `estimatedContentHeight` and `estimatedOverflow`). Document table autofit read-back behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)