### PR TITLE
docs: update Slides skill to snake_case parameter names

### DIFF
--- a/plugins/google-slides-toolforest/SKILL.md
+++ b/plugins/google-slides-toolforest/SKILL.md
@@ -12,11 +12,11 @@ description: >
 
 Follow these steps for every presentation build:
 
-1. **Create presentation** → create_presentation returns presentationId, default slide ID, available layouts, and page dimensions (standard: 9,144,000 × 5,143,500 EMU).
+1. **Create presentation** → create_presentation returns presentation_id, default slide ID, available layouts, and page dimensions (standard: 9,144,000 × 5,143,500 EMU).
 2. **Set theme** → set_theme for master background, default text color, heading + body font families, accent colors. Never skip this step. Never default to Arial — always choose an intentional pairing (see references/fonts.md).
 3. **Build and verify each slide — ONE AT A TIME.** For each slide, complete ALL of the following before moving to the next:
 
-   a. **Add the slide** → Use add_slide with layoutId (prefer "p12" / BLANK for full control). Delete default placeholders (i0, i1) on first slide if building a custom title.
+   a. **Add the slide** → Use add_slide with layout_id (prefer "p12" / BLANK for full control). Delete default placeholders (i0, i1) on first slide if building a custom title.
    b. **Populate the slide** → Add shapes, text boxes, tables, images.
    c. **Verify the slide** → Call get_slide_content_elements and check EVERY element against the verification checks below.
    d. **Fix any failures** → If any check fails, fix the issue, then re-verify. Repeat until the slide passes.
@@ -35,7 +35,7 @@ After calling get_slide_content_elements, check ALL of the following. If ANY che
 
 **Text overflow:**
 - estimatedOverflow: false on all text boxes and tables
-- If autofit was used: scaleFactor ≥ 0.7. If below 0.7, the element MUST be rebuilt — enlarge the box, reduce content, or split across elements.
+- If autofit was used: scale_factor ≥ 0.7. If below 0.7, the element MUST be rebuilt — enlarge the box, reduce content, or split across elements.
 
 **Font sizes (tiered minimum):**
 - Body text, bullets, descriptions: ≥ 14pt
@@ -55,18 +55,18 @@ These are the highest-signal failure points. They are non-obvious and will waste
 
 ### Gotcha 1: autofit Is Boolean, Not String
 
-Always set autofit: true + minFontSize: 10 on content text boxes. Check scaleFactor in the response — values below 0.7 mean the box is too small and MUST be rebuilt.
+Always set autofit: true + min_font_size: 10 on content text boxes. Check scale_factor in the response — values below 0.7 mean the box is too small and MUST be rebuilt.
 
-✅ autofit: true, minFontSize: 10
+✅ autofit: true, min_font_size: 10
 ❌ autofit: "SHAPE_AUTOFIT" → ValidationError
-❌ minFontSize: 8 → allows illegible text
+❌ min_font_size: 8 → allows illegible text
 
 ### Gotcha 2: Hex Encoding for Images, Never Base64
 
 Claude/Cowork's content filter scans outgoing tool parameters for API key-like patterns. Base64 image data can trigger this, silently corrupting the image. Always use hex encoding.
 
-✅ imageEncoding: "hex", imageData: "89504e470d0a1a0a..."
-❌ imageEncoding: "base64" (may be corrupted by content filter)
+✅ image_encoding: "hex", image_data: "89504e470d0a1a0a..."
+❌ image_encoding: "base64" (may be corrupted by content filter)
 
 Always read hex data from file programmatically. Never hand-type or split hex strings manually.
 

--- a/plugins/google-slides-toolforest/references/design-patterns.md
+++ b/plugins/google-slides-toolforest/references/design-patterns.md
@@ -42,4 +42,4 @@ Use create_gradient to add gradient backgrounds and rectangular gradient fills t
 - Rectangular gradient fills — place anywhere at any size to simulate a gradient-filled rectangle.
 - Limitation: create_gradient produces rectangular images. For non-rectangular shapes (rounded rectangles, circles), the gradient won't clip to the shape's edges. For those, layer the gradient behind a shape with a transparent fill, which only partially works.
 
-For additional visual depth, also consider: alternating dark/light backgrounds, semi-transparent overlays via fillAlpha, accent-colored bars and dividers, and contrasting card colors.
+For additional visual depth, also consider: alternating dark/light backgrounds, semi-transparent overlays via fill_alpha, accent-colored bars and dividers, and contrasting card colors.

--- a/plugins/google-slides-toolforest/references/images-and-charts.md
+++ b/plugins/google-slides-toolforest/references/images-and-charts.md
@@ -1,12 +1,12 @@
 Read this file when embedding images or charts into slides.
 ## Image Embedding via add_image
-The add_image tool supports three source modes: imageUrl (public URL), imageData (single encoded string), and imageChunks (array of encoded strings). Position and size are in EMU.
+The add_image tool supports three source modes: image_url (public URL), image_data (single encoded string), and image_chunks (array of encoded strings). Position and size are in EMU.
 ### Critical: Always Use Hex Encoding
 Claude/Cowork’s content filter scans outgoing tool parameters for API key-like patterns. Base64 data can trigger false positives, silently corrupting the image with [API_KEY] replacements. Hex encoding (characters 0–9, a–f only) avoids this entirely.
-✅ imageEncoding: "hex", imageData: "89504e470d0a1a0a..."
-❌ imageEncoding: "base64", imageData: "iVBORw0KGgo..." (may be corrupted)
+✅ image_encoding: "hex", image_data: "89504e470d0a1a0a..."
+❌ image_encoding: "base64", image_data: "iVBORw0KGgo..." (may be corrupted)
 ### Always Read Hex From File — Never Hand-Type
-Early attempts to manually chunk hex strings introduced duplicate data and byte-level corruption, producing invalid PNGs. When splitting into imageChunks, always do it programmatically:
+Early attempts to manually chunk hex strings introduced duplicate data and byte-level corruption, producing invalid PNGs. When splitting into image_chunks, always do it programmatically:
 chunk_size = 4000
 chunks = [hex_str[i:i+chunk_size] for i in range(0, len(hex_str), chunk_size)]
 assert ''.join(chunks) == hex_str  # verify reconstruction
@@ -14,8 +14,8 @@ assert ''.join(chunks) == hex_str  # verify reconstruction
 The add_image API accepts up to 1MB decoded. However, hex-encoded image data must fit in the LLM’s context window (~25K tokens per Read call ≈ 20–25KB decoded). Recommendations by image type:
 - Small icons/decorations (< 20KB): add_image with hex encoding
 - Charts and data viz (any size): Google Sheets → embed_chart (see below)
-- Photos/logos with public URL (any size): add_image with imageUrl
-- Large local images (20KB–1MB): Use imageUrl if available, or the Sheets pipeline
+- Photos/logos with public URL (any size): add_image with image_url
+- Large local images (20KB–1MB): Use image_url if available, or the Sheets pipeline
 
 ### Generating Simple Icons with Pillow
 Geometric icons (circles, arrows, checkmarks) can be generated locally at 1–5KB using Pillow, then hex-encoded. Keep to 200–400px dimensions, PNG with transparency.
@@ -27,10 +27,10 @@ For any chart or data visualization, always use Google Sheets → Google Slides 
 - No encoding, no content filter issues, no token limits
 
 ### Sheets Chart Workflow
-Step 1: create_spreadsheet → returns spreadsheetId
+Step 1: create_spreadsheet → returns spreadsheet_id
 Step 2: update_values with headers in row 1, data below
 Step 3: create_chart with chartType, sourceRange, title, seriesColors matching the deck’s theme
-Step 4: embed_chart with linkingMode: "LINKED" (live data) or "NOT_LINKED_IMAGE" (static snapshot)
+Step 4: embed_chart with linking_mode: "LINKED" (live data) or "NOT_LINKED_IMAGE" (static snapshot)
 ### Chart Styling Tips
 - Use seriesColors to match the presentation’s color palette from config.json
 - Set legendPosition: "none" for single-series charts

--- a/plugins/google-slides-toolforest/references/tables-and-formatting.md
+++ b/plugins/google-slides-toolforest/references/tables-and-formatting.md
@@ -1,8 +1,8 @@
 Read this file when creating tables or text-heavy slides. The multi-run technique is essential for professional-quality output.
 ## Table Creation
-- Use create_table with values for initial content, headerFillColorHex for styled headers
-- alternateRowColorHex adds automatic row striping
-- Set autofit: true to automatically shrink header and body font sizes to fit within the specified table height (assumes Arial metrics). Set minFontSize: 10 to control the floor. Check autofitApplied and scaleFactor in the response — values below 0.7 mean the table is too dense for the space and MUST be rebuilt (enlarge the table, reduce content, or split across slides).
+- Use create_table with values for initial content, header_fill_color_hex for styled headers
+- alternate_row_color_hex adds automatic row striping
+- Set autofit: true to automatically shrink header and body font sizes to fit within the specified table height (assumes Arial metrics). Set min_font_size: 10 to control the floor. Check autofitApplied and scale_factor in the response — values below 0.7 mean the table is too dense for the space and MUST be rebuilt (enlarge the table, reduce content, or split across slides).
 - get_slide_content_elements returns estimatedContentHeight and estimatedOverflow for tables, plus an autofit field showing whether autofit was applied and the scale factor used
 
 ## Multi-Run Text Formatting — The Key to Visual Hierarchy
@@ -18,13 +18,13 @@ The add_text_box tool supports multiple runs per paragraph, each with independen
 ### Example: KPI Card with Multi-Run Hierarchy
 ❌ Bad pattern (flat, uniform):
 paragraphs: [{"runs": [{"text": "17M+\nEVs Sold",
-  "fontSize": 14, "textColorHex": "#00D4AA"}]}]
+  "font_size": 14, "text_color_hex": "#00D4AA"}]}]
 ✅ Good pattern (visual hierarchy):
 paragraphs: [{"runs": [
-  {"text": "17M+", "fontSize": 36, "bold": true,
-   "textColorHex": "#00D4AA"},
-  {"text": "\nEVs Sold in 2024", "fontSize": 12,
-   "textColorHex": "#A0AEC0"}
+  {"text": "17M+", "font_size": 36, "bold": true,
+   "text_color_hex": "#00D4AA"},
+  {"text": "\nEVs Sold in 2024", "font_size": 12,
+   "text_color_hex": "#A0AEC0"}
 ], "alignment": "LEFT"}]
 ### Where to Apply Multi-Run Formatting
 - Bullet lists: Bold lead-in phrase in accent color, followed by regular-weight detail in body color

--- a/plugins/google-slides-toolforest/scripts/verify_slide.md
+++ b/plugins/google-slides-toolforest/scripts/verify_slide.md
@@ -8,7 +8,7 @@ Run this checklist after building EVERY slide. Call get_slide_content_elements a
 ## Text and Table Overflow Checks
 - Check estimatedOverflow: false on all text boxes and tables.
 - Compare estimatedContentHeight to the element’s actual height.
-- If autofit was used (text boxes or tables), check scaleFactor — values below 0.7 mean the element is too small for the content. **This is a hard failure: delete and rebuild the element** (enlarge the box, reduce content, or split across elements).
+- If autofit was used (text boxes or tables), check scale_factor — values below 0.7 mean the element is too small for the content. **This is a hard failure: delete and rebuild the element** (enlarge the box, reduce content, or split across elements).
 
 ## Contrast Checks
 - Check contrastRatio on all text elements — minimum 4.5:1 for body text (WCAG AA), 3.0:1 for large text (>=18pt or >=14pt bold)
@@ -25,7 +25,7 @@ Run this checklist after building EVERY slide. Call get_slide_content_elements a
 
 ## Common Issues to Watch For
 - Text box autofit reported as googleAutofitType: "NONE" on read-back even when applied during creation — this is expected because Toolforest pre-scales font sizes at creation time
-- Table autofit is reported correctly via the autofit field (autofitApplied, scaleFactor) stored as presentation metadata
+- Table autofit is reported correctly via the autofit field (autofitApplied, scale_factor) stored as presentation metadata
 - Default placeholder elements (i0, i1) not deleted on first slide — these overlap custom content
 - z-order: get_slide_content_elements returns elements in z-order, later elements render on top — verify layering is correct
 - Master element injection via set_master_elements may add decorative shapes to every new slide — account for these in layout


### PR DESCRIPTION
## Summary

All Google Workspace toolkit parameters were migrated from camelCase to snake_case in toolforest_tools (PRs #1031-#1035). This updates the Slides skill prompts and reference docs to match.

## Changes

- `SKILL.md` — `presentationId` → `presentation_id`, `layoutId` → `layout_id`, etc.
- `references/tables-and-formatting.md` — JSON examples updated
- `references/images-and-charts.md` — `imageUrl` → `image_url`, etc.
- `references/design-patterns.md` — `fillAlpha` → `fill_alpha`
- `scripts/verify_slide.md` — `scaleFactor` → `scale_factor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)