### PR TITLE
docs: update Slides skill for P1 param renames

### DIFF
--- a/plugins/google-slides-toolforest/SKILL.md
+++ b/plugins/google-slides-toolforest/SKILL.md
@@ -55,11 +55,11 @@ These are the highest-signal failure points. They are non-obvious and will waste
 
 ### Gotcha 1: autofit Is Boolean, Not String
 
-Always set autofit: true + min_font_size: 10 on content text boxes. Check scale_factor in the response — values below 0.7 mean the box is too small and MUST be rebuilt.
+Always set autofit: true + min_font_size_pt: 10 on content text boxes. Check scale_factor in the response — values below 0.7 mean the box is too small and MUST be rebuilt.
 
-✅ autofit: true, min_font_size: 10
+✅ autofit: true, min_font_size_pt: 10
 ❌ autofit: "SHAPE_AUTOFIT" → ValidationError
-❌ min_font_size: 8 → allows illegible text
+❌ min_font_size_pt: 8 → allows illegible text
 
 ### Gotcha 2: Hex Encoding for Images, Never Base64
 

--- a/plugins/google-slides-toolforest/references/tables-and-formatting.md
+++ b/plugins/google-slides-toolforest/references/tables-and-formatting.md
@@ -1,8 +1,8 @@
 Read this file when creating tables or text-heavy slides. The multi-run technique is essential for professional-quality output.
 ## Table Creation
-- Use create_table with values for initial content, header_fill_color_hex for styled headers
-- alternate_row_color_hex adds automatic row striping
-- Set autofit: true to automatically shrink header and body font sizes to fit within the specified table height (assumes Arial metrics). Set min_font_size: 10 to control the floor. Check autofitApplied and scale_factor in the response — values below 0.7 mean the table is too dense for the space and MUST be rebuilt (enlarge the table, reduce content, or split across slides).
+- Use create_table with values for initial content, header_fill_color for styled headers
+- alternate_row_color adds automatic row striping
+- Set autofit: true to automatically shrink header and body font sizes to fit within the specified table height (assumes Arial metrics). Set min_font_size_pt: 10 to control the floor. Check autofitApplied and scale_factor in the response — values below 0.7 mean the table is too dense for the space and MUST be rebuilt (enlarge the table, reduce content, or split across slides).
 - get_slide_content_elements returns estimatedContentHeight and estimatedOverflow for tables, plus an autofit field showing whether autofit was applied and the scale factor used
 
 ## Multi-Run Text Formatting — The Key to Visual Hierarchy
@@ -18,13 +18,13 @@ The add_text_box tool supports multiple runs per paragraph, each with independen
 ### Example: KPI Card with Multi-Run Hierarchy
 ❌ Bad pattern (flat, uniform):
 paragraphs: [{"runs": [{"text": "17M+\nEVs Sold",
-  "font_size": 14, "text_color_hex": "#00D4AA"}]}]
+  "font_size_pt": 14, "text_color": "#00D4AA"}]}]
 ✅ Good pattern (visual hierarchy):
 paragraphs: [{"runs": [
-  {"text": "17M+", "font_size": 36, "bold": true,
-   "text_color_hex": "#00D4AA"},
-  {"text": "\nEVs Sold in 2024", "font_size": 12,
-   "text_color_hex": "#A0AEC0"}
+  {"text": "17M+", "font_size_pt": 36, "bold": true,
+   "text_color": "#00D4AA"},
+  {"text": "\nEVs Sold in 2024", "font_size_pt": 12,
+   "text_color": "#A0AEC0"}
 ], "alignment": "LEFT"}]
 ### Where to Apply Multi-Run Formatting
 - Bullet lists: Bold lead-in phrase in accent color, followed by regular-weight detail in body color


### PR DESCRIPTION
Updates Slides skill docs for P1 parameter standardization (toolforest_tools #1039):
- `min_font_size` → `min_font_size_pt`
- `header_fill_color_hex` → `header_fill_color`
- `alternate_row_color_hex` → `alternate_row_color`
- `font_size` → `font_size_pt` in code examples
- `text_color_hex` → `text_color` in code examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)