### PR TITLE
feat(sheets): add google-sheets-toolforest skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,15 @@
       "category": "productivity",
       "tags": ["google-slides", "presentations", "toolforest", "mcp", "design"],
       "strict": true
+    },
+    {
+      "name": "google-sheets-toolforest",
+      "source": "./plugins/google-sheets-toolforest",
+      "description": "Best practices for building Google Sheets via Toolforest MCP. Theme presets, formula patterns, cross-tab references, dashboard layouts, conditional formatting on categorical data, dynamic ranking tables, and batch-wrapper gotchas — all derived from end-to-end builds verified to render cleanly.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "tags": ["google-sheets", "spreadsheets", "dashboards", "toolforest", "mcp"],
+      "strict": true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Best practices for building Google Slides presentations via Toolforest MCP. Incl
 
 Requires: Toolforest Google Slides MCP connector
 
+### google-sheets-toolforest
+Best practices for building Google Sheets via Toolforest MCP. Includes:
+- Default Toolforest brand theme + four audience-mapped presets (Boardroom, Eng Scorecard, Ops Tracker, Marketing Rollup)
+- Ten core patterns (template-and-duplicate, INDIRECT cross-tab refs, 2D matrix lookups, dynamic ranking, categorical conditional formatting, freeze/merge layout safety, the PERCENT-format trap, verification trifecta)
+- Batch-wrapper gotchas (camelCase keys, raw API shapes for charts/validation/conditional formats)
+- Common gotchas quick reference
+- End-to-end worked example (multi-tab financial dashboard)
+
+Requires: Toolforest Google Sheets MCP connector
+
 ## Adding New Skills
 
 To add a new toolkit skill (e.g., Google Docs, Sheets, Gmail):

--- a/plugins/google-sheets-toolforest/.claude-plugin/plugin.json
+++ b/plugins/google-sheets-toolforest/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "google-sheets-toolforest",
+  "description": "Best practices for building Google Sheets via Toolforest MCP. Theme presets, formula patterns, cross-tab references, dashboard layouts, conditional formatting on categorical data, dynamic ranking tables, and batch-wrapper gotchas — all derived from end-to-end builds verified to render cleanly.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Toolforest (toolforest.io)"
+  },
+  "skills": ["./"]
+}

--- a/plugins/google-sheets-toolforest/SKILL.md
+++ b/plugins/google-sheets-toolforest/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: google-sheets-toolforest
+description: >
+  Use when creating or editing Google Sheets via Toolforest MCP tools.
+  Triggers on: create_spreadsheet, create_sheet, update_values,
+  batch_update_values, fill_formula, add_named_range, set_conditional_format,
+  freeze_panes, merge_cells, batch_format_cells, batch_create_chart,
+  duplicate_sheet, set_data_validation, check_spreadsheet_errors, or any
+  request to build, design, or modify a multi-tab dashboard, tracker,
+  scorecard, or rollup using Google Sheets through the Toolforest connector.
+---
+
+# google-sheets-toolforest
+
+Best practices for building Google Sheets via the Toolforest MCP. Covers theme presets, formula patterns that survive scale, cross-tab references, dashboard layouts, conditional formatting on categorical data, dynamic ranking tables, and batch-wrapper gotchas — all derived from end-to-end builds that were verified to render and resolve cleanly.
+
+The toolkit has 73 tools. This skill does not enumerate them. It gives you the patterns that recur across real builds and the gotchas the Google Sheets API itself doesn't tell you about.
+
+## When to load this skill
+
+Load this skill whenever a task involves the `google_sheets-*` tools, especially when the user wants:
+
+- A multi-tab dashboard, tracker, or scorecard
+- Cross-sheet rollups (a master tab pulling from N data tabs)
+- A repeating layout (per-month, per-customer, per-run) — the template-and-duplicate idiom
+- Conditional formatting beyond a single threshold
+- Charts driven by computed/pivoted data, not the raw table
+- Anything that will be shared with non-author readers (formatting matters)
+
+Skip it for one-off `get_values` reads, single-cell updates, or trivial appends — direct tool calls are fine.
+
+## Default theme
+
+Apply the Toolforest brand theme unless the request implies a different mood (boardroom report, ops tracker, eng scorecard, marketing rollup). Brand:
+
+- **Title banner:** background `#1F4E79`, white Montserrat 16pt bold, left-padded
+- **Section headers:** background `#B8B8B8`, Montserrat 12pt bold
+- **Column headers:** background `#4C4C4C`, white Source Sans 3 bold, centered
+- **Banding:** header `#4C4C4C`, alternating `#FFFFFF` / `#F2F2F2`
+- **Body:** Source Sans 3 for prose columns, IBM Plex Mono for IDs/timestamps/code-like data
+- **Accents:** green `#2E7D32` (positive/accepted), red `#B71C1C` (negative/rejected), amber `#F9A825` (warning/in-progress), blue `#1976D2` (informational)
+
+For audience-specific themes (Boardroom, Eng Scorecard, Ops Tracker, Marketing Rollup) see `references/themes.md`.
+
+## The patterns that matter
+
+### 1. Template-and-duplicate
+
+For any workflow producing structurally identical sheets (eval runs, monthly reports, per-customer tabs):
+
+1. Create a `_template` tab. Apply all formatting, conditional formats, validation, freeze, banding **on the template**.
+2. Use `duplicate_sheet` to create each instance. The duplicate carries over freeze rows, conditional formats, validation, tab color, and column widths.
+3. Populate values only — formatting is already in place.
+
+Two API calls per new instance instead of fifteen. The template should have a `_` prefix and gray tab color so it reads as infrastructure, not data.
+
+### 2. Cross-tab references with INDIRECT
+
+When a master tab needs to roll up from N data tabs whose names are stored as values in column A:
+
+```
+=INDIRECT("'" & A5 & "'!F4:F1000")
+```
+
+The single quotes around the sheet name are **required** if any sheet name contains a hyphen, space, or other non-alphanumeric character (e.g. `run_2026-04-26`). Without them, the formula will silently return `#REF!`. Always use the quoted form — it's harmless on plain names and necessary on hyphenated ones.
+
+This pattern lets you add a new run/month/customer by appending one row + duplicating the template tab. No formula edits needed on the overview tab.
+
+### 3. 2D matrix lookups
+
+`fill_formula` only fills along one axis (vertical OR horizontal). For a 2D matrix where the formula varies by both row and column (assets × venues, dates × metrics):
+
+**Option A — call `fill_formula` once per column**, with the column letter hard-coded in the formula and `{row}` as the placeholder. This is the cleanest approach for a few columns.
+
+**Option B — hand-author the formula array** and push via `update_values`. Generate it programmatically in code.
+
+The lookup formula itself, for an arbitrary (row_key, col_key) pair against a 3-column table:
+
+```
+=INDEX(SourceData,
+  MATCH(1, (INDEX(SourceData,,col_key_idx)=row_key) * (INDEX(SourceData,,row_key_idx)=col_key), 0),
+  return_col)
+```
+
+This is an array formula that handles non-sorted source data without requiring helper columns. Wrap in `IFERROR` for empty cells.
+
+### 4. Long formulas across many rows
+
+Three rules for keeping long formulas maintainable:
+
+1. **Use named ranges for source data**, not raw addresses. `FundingData` instead of `'Funding Rates'!A2:F121`. Update the range once via `add_named_range`, every dependent formula picks it up.
+2. **Anchor the lookup keys with `$`**, not the lookup ranges. `$A6` and `B$5` so the formula can be filled in either direction without breaking.
+3. **Verify with `formulaResults`, not a separate read.** Every `update_values` and `batch_update_values` response includes a `formulaResults` field showing the resolved values. Use that to confirm formulas evaluated as intended — saves a `get_values` round-trip.
+
+### 5. Dynamic sort/rank tables
+
+Use `QUERY` for a top-N table that updates as the source changes:
+
+```
+=IFERROR(
+  QUERY(Pipeline!A4:M100,
+    "select A, B, C, D, F where D >= 0 and L = '' order by D asc limit 5",
+    0),
+  "No matching rows")
+```
+
+Two gotchas the Sheets docs are quiet about:
+
+- The QUERY result **does not inherit number/date formatting from the source**. If the source column is a date, the QUERY output will show raw serial numbers (e.g. 46143). Format the destination range explicitly after.
+- The QUERY column references are positional letters within the source range, not the spreadsheet's absolute columns. If the source range starts at column C, then "select A" pulls from C.
+
+For ranking against a calculated metric, `LARGE`/`SMALL` + `INDEX/MATCH` works inline:
+
+```
+=INDEX(SourceRange, MATCH(LARGE(MetricColumn, 1), MetricColumn, 0), name_col)
+```
+
+### 6. Conditional formatting on categorical data
+
+When categories share substrings (like "Submitted" vs "Ready to Submit", or "Drafting" vs "Re-drafting"), the `text_contains` rule type with default match mode will mis-fire — "Submitted" matches both. **Always pass `match_type: "exact"` for categorical/discrete state values.** Only use the default `contains` match for true substring searches (free-text notes columns).
+
+The `set_conditional_format` tool exposes this directly. Worked example: see `references/categorical_formatting.md`.
+
+### 7. Layout safety: freeze, merge, and column-freeze
+
+Two boundary rules that the API enforces but the Sheets UI does not:
+
+1. **Freeze before merging.** If you freeze rows 1–5 and then merge a title across `A1:I1`, that's fine. If you merge first and then freeze, the merge can break the freeze silently.
+2. **Don't merge across a column-freeze.** If you freeze column A and merge `A1:I1` for a title banner, the merge fails with "can't merge frozen and non-frozen columns". Title banners want only a row freeze, not both. Freeze column A is for label-column scrolling, which is incompatible with a wide top-row banner.
+
+The recommended order: freeze rows → format → merge title within the frozen zone → freeze column (only if needed and no banner crosses it).
+
+### 8. Number formatting: PERCENT expects fractions
+
+The PERCENT number format multiplies by 100 for display. So `0.0261` formatted as PERCENT shows `2.61%`. If you have a percentage value that's already in percentage units (e.g. `2.61` meaning 2.61%), use a NUMBER format with pattern `"0.00\"%\""` instead — appending a literal `%` character.
+
+The annualized funding rate columns in a financial dashboard are usually already-multiplied (`12.0860` for 12.0860%), so they need the `0.00"%"` pattern, not PERCENT type. Reaching for PERCENT on already-percentage data turns 2.61% into 261%.
+
+### 9. Banding interacts with conditional formatting
+
+Banding paints the whole range. Conditional formatting paints over banding only on matched cells. This is usually what you want — the banding gives the table its baseline rhythm; the conditional formats highlight signal on top.
+
+Apply in this order: banding first, conditional formats second. Reversing it doesn't break anything but can leave you debugging why a "highlighted" cell looks no different from its neighbors (banding repainted on top).
+
+### 10. The verification trifecta
+
+Before declaring a sheet done, run these three reads:
+
+1. `check_spreadsheet_errors` with `detect_circular_refs: true`. Catches `#REF!`, `#N/A`, `#VALUE!`, broken named ranges, circular dependencies. Should return zero errors.
+2. `get_notes` over any range you wrote notes to. Confirms unicode/multiline content survived round-trip.
+3. Spot-check `formulaResults` from the most recent batch updates. Reading the response is free; a separate `get_values` is a round-trip.
+
+## Batch wrapper gotchas
+
+Several `batch_*` tools accept a different argument shape than their singular counterparts. The pattern is consistent: **singular wrappers accept a friendly simplified shape; batch wrappers forward to the raw Google API and require the raw shape.** Until the toolkit harmonizes these, use the raw form for any batch call. See `references/batch_wrappers.md` for the specific differences and worked-example payloads for:
+
+- `batch_create_chart` (camelCase keys instead of snake_case)
+- `batch_set_data_validation` (raw `{condition: {...}}` form, not `{type, values}`)
+- `batch_set_column_width` (the `widths` property is shaped differently from singular `set_column_width`)
+- `batch_add_conditional_format` (raw `{booleanRule}` / `{gradientRule}`, not the high-level `rule_type` shape)
+
+Defaulting to the singular tools where possible avoids this entirely, at the cost of more API calls. For 1–4 operations, prefer singular. For 5+, accept the raw shape and batch.
+
+## Common gotchas (quick reference)
+
+- **`delete_sheet` takes a numeric `sheet_id`, not a name** — get it from `create_sheet` response or `get_spreadsheet_metadata`. Every other write tool takes the name.
+- **`create_spreadsheet` always creates a default `Sheet1`** — delete it (sheet_id is typically 0) before creating named tabs, or you'll have an orphan.
+- **`fill_formula` is single-axis only** — see pattern #3 above for 2D fills.
+- **`auto_resize_columns` interacts badly with merged title banners** — the merged width gets attributed to individual columns, blowing them up. Pass `max_width_px: 240` (or similar) as a guard, or auto-resize before merging.
+- **`min_font_size_pt` is not a Sheets concept**, only Slides — Sheets autofit shrinks freely. Use explicit column widths via `set_column_width` if you need a hard floor on rendered text size.
+
+## End-to-end worked example
+
+A complete walk-through (multi-tab financial dashboard with synthetic data, named ranges, formulas, conditional formats, charts, sharing) is in `references/worked_example_financial_dashboard.md`. The example builds a multi-venue funding-rate monitor used to verify this skill.
+
+## Verification checklist
+
+Before handing off a finished sheet:
+
+- [ ] `check_spreadsheet_errors` returns zero errors and zero broken refs
+- [ ] At least one read confirms `INDIRECT` cross-tab refs resolve (not silently `#REF!`)
+- [ ] PERCENT-formatted cells contain fractional values, not pre-multiplied percentages
+- [ ] Categorical conditional formats use `match_type: "exact"`
+- [ ] Title banner exists within the frozen zone, no column-freeze if a wide banner is merged
+- [ ] Banding applied before conditional formatting on the same range
+- [ ] All notes round-trip via `get_notes`
+- [ ] If shared link generated, it's `reader` unless the user explicitly asked for `writer`

--- a/plugins/google-sheets-toolforest/references/batch_wrappers.md
+++ b/plugins/google-sheets-toolforest/references/batch_wrappers.md
@@ -1,0 +1,179 @@
+# Batch wrapper argument shapes
+
+The pattern: singular wrappers accept a friendly simplified shape that the toolkit translates internally; `batch_*` wrappers forward directly to the Google Sheets API and require the raw API form. Below are the specific differences with verified payloads.
+
+## batch_create_chart
+
+`create_chart` accepts snake_case (`chart_type`, `source_range`, `anchor_cell`, `series_colors`, `header_row`, `legend_position`, `x_axis_title`, `y_axis_title`).
+
+`batch_create_chart` requires camelCase: `chartType`, `sourceRange`, `anchorCell`, `seriesColors`, `headerRow`, `legendPosition`, `xAxisTitle`, `yAxisTitle`.
+
+```python
+# WRONG — fails with: charts[0] missing 'chartType'
+batch_create_chart(charts=[{
+  "sheet": "Charts",
+  "source_range": "A4:E10",
+  "chart_type": "line",
+  "title": "BTC Funding Rate",
+  "anchor_cell": "G3"
+}])
+
+# RIGHT
+batch_create_chart(charts=[{
+  "sheet": "Charts",
+  "sourceRange": "A4:E10",
+  "chartType": "line",
+  "title": "BTC Funding Rate",
+  "anchorCell": "G3",
+  "seriesColors": ["#F0B90B", "#F7A600", "#1976D2", "#00B874"],
+  "legendPosition": "right",
+  "headerRow": True
+}])
+```
+
+## batch_set_data_validation
+
+`set_data_validation` accepts `{type: "dropdown", values: [...]}`, `{type: "number_between", min, max}`, `{type: "checkbox"}`.
+
+`batch_set_data_validation` requires the raw API form with `condition` wrapping:
+
+```python
+# Dropdown backed by a Reference range
+{
+  "range": "F4:F100",
+  "rule": {
+    "condition": {
+      "type": "ONE_OF_RANGE",
+      "values": [{"userEnteredValue": "=Reference!$C$2:$C$9"}]
+    },
+    "showCustomUi": True,
+    "strict": True
+  },
+  "sheet": "Pipeline"
+}
+
+# Dropdown with hardcoded values
+{
+  "range": "K4:K100",
+  "rule": {
+    "condition": {
+      "type": "ONE_OF_LIST",
+      "values": [
+        {"userEnteredValue": "High"},
+        {"userEnteredValue": "Medium"},
+        {"userEnteredValue": "Low"}
+      ]
+    },
+    "showCustomUi": True,
+    "strict": True
+  },
+  "sheet": "Pipeline"
+}
+
+# Checkbox
+{
+  "range": "F4:F1000",
+  "rule": {
+    "condition": {"type": "BOOLEAN"},
+    "strict": True
+  },
+  "sheet": "_run_template"
+}
+
+# Number between
+{
+  "range": "J4:J1000",
+  "rule": {
+    "condition": {
+      "type": "NUMBER_BETWEEN",
+      "values": [
+        {"userEnteredValue": "1"},
+        {"userEnteredValue": "5"}
+      ]
+    },
+    "strict": False
+  },
+  "sheet": "_run_template"
+}
+
+# Date is valid
+{
+  "range": "C4:C100",
+  "rule": {
+    "condition": {"type": "DATE_IS_VALID"},
+    "inputMessage": "Enter a valid date (YYYY-MM-DD)",
+    "strict": False
+  },
+  "sheet": "Pipeline"
+}
+```
+
+Common condition types: `ONE_OF_LIST`, `ONE_OF_RANGE`, `NUMBER_BETWEEN`, `NUMBER_GREATER_THAN_EQ`, `NUMBER_LESS_THAN_EQ`, `DATE_IS_VALID`, `DATE_AFTER`, `BOOLEAN`, `TEXT_CONTAINS`, `TEXT_EQ`, `CUSTOM_FORMULA`.
+
+## batch_set_column_width
+
+`set_column_width` takes `start_index`, `end_index`, `pixel_size`.
+
+`batch_set_column_width` takes a `widths` array where each entry has its own column range:
+
+```python
+batch_set_column_width(
+  spreadsheet_id="...",
+  widths=[
+    {"sheet": "Pipeline", "startIndex": 0, "endIndex": 1, "pixelSize": 240},  # col A
+    {"sheet": "Pipeline", "startIndex": 12, "endIndex": 13, "pixelSize": 320},  # col M
+    {"sheet": "Dashboard", "startIndex": 0, "endIndex": 5, "pixelSize": 150},   # cols A-E
+  ]
+)
+```
+
+Note: `endIndex` is **exclusive**. To set width on column A only, use `startIndex: 0, endIndex: 1`. To set columns A through E, use `startIndex: 0, endIndex: 5`.
+
+## batch_add_conditional_format
+
+`set_conditional_format` exposes a high-level API with `rule_type` of `color_scale`, `threshold`, `text_contains`, `top_n`, `custom_formula`. This is by far the friendlier interface.
+
+`batch_add_conditional_format` requires the raw `booleanRule` or `gradientRule` shape:
+
+```python
+# Threshold (boolean rule)
+{
+  "sheet": "Pipeline",
+  "range": "D4:D100",
+  "rule": {
+    "booleanRule": {
+      "condition": {
+        "type": "NUMBER_LESS",
+        "values": [{"userEnteredValue": "14"}]
+      },
+      "format": {
+        "backgroundColor": {"red": 1.0, "green": 0.80, "blue": 0.82},
+        "textFormat": {"bold": True, "foregroundColor": {"red": 0.72}}
+      }
+    }
+  }
+}
+
+# Color scale (gradient rule)
+{
+  "sheet": "Live Dashboard",
+  "range": "B6:E10",
+  "rule": {
+    "gradientRule": {
+      "minpoint": {"color": {"red": 0.10, "green": 0.46, "blue": 0.82}, "type": "MIN"},
+      "midpoint": {"color": {"red": 1, "green": 1, "blue": 1}, "type": "NUMBER", "value": "15"},
+      "maxpoint": {"color": {"red": 0.83, "green": 0.18, "blue": 0.18}, "type": "MAX"}
+    }
+  }
+}
+```
+
+**Recommendation: prefer `set_conditional_format` over `batch_add_conditional_format` even for multi-rule workflows.** Calling the singular tool 5–10 times is rarely measurable in user-perceived latency, and the friendly interface (especially `match_type: "exact"` on `text_contains`, or named presets like `red_white_green` on `color_scale`) eliminates a class of bugs.
+
+## When to batch and when not to
+
+Default to **singular** for ≤4 operations of a kind. The cleaner API more than pays for the extra calls.
+
+Default to **batch** for 5+ operations of a kind. The throughput win matters once you're loading a sheet with several dozen formats or formulas.
+
+If the operation is one-time setup that runs in the background, singular is almost always fine. If it's part of a hot path the user is waiting on, batch carefully.

--- a/plugins/google-sheets-toolforest/references/categorical_formatting.md
+++ b/plugins/google-sheets-toolforest/references/categorical_formatting.md
@@ -1,0 +1,86 @@
+# Conditional formatting on categorical text
+
+The `set_conditional_format` tool's `text_contains` rule type defaults to substring matching. For categorical state columns where values share substrings, this mis-fires.
+
+## The trap
+
+Status values in a college application tracker include:
+
+- Researching
+- Drafting
+- Ready to Submit
+- **Submitted**
+- Decision Pending
+- Accepted
+- Rejected
+
+A naïve rule with `rule_type: "text_contains"`, `text: "Submitted"` will match both "Submitted" and "Ready to Submit". The intended highlight on submitted-only applications instead highlights drafts.
+
+## The fix
+
+Pass `match_type: "exact"`:
+
+```python
+set_conditional_format(
+  sheet="Pipeline",
+  range="F4:F100",
+  rule_type="text_contains",
+  text="Submitted",
+  match_type="exact",  # <-- this is the critical bit
+  background_color="#FFF9C4",
+  text_color="#5D4037"
+)
+```
+
+`match_type` options: `contains` (default), `not_contains`, `starts_with`, `ends_with`, `exact`.
+
+## When to use which
+
+- **`exact`** — categorical state values, status enums, priority tiers (Low/Medium/High), boolean-like text. Default to this for any column with a finite set of allowed values, especially when those values share words.
+- **`contains`** — free-text columns where you're flagging keywords (notes containing "blocker", titles containing "draft").
+- **`starts_with` / `ends_with`** — IDs with prefixes (`ERR-` for errors, `_test` for test artifacts).
+
+## A complete worked layer
+
+For a status column with 5+ states, write one rule per state. Use the brand accent palette:
+
+```python
+# Researching → no highlight (default state, lets banding show through)
+
+set_conditional_format(sheet="Pipeline", range="F4:F100",
+  rule_type="text_contains", text="Drafting", match_type="exact",
+  background_color="#FFE0B2", text_color="#E65100", bold=True)
+
+set_conditional_format(sheet="Pipeline", range="F4:F100",
+  rule_type="text_contains", text="Submitted", match_type="exact",
+  background_color="#FFF9C4", text_color="#5D4037")
+
+set_conditional_format(sheet="Pipeline", range="F4:F100",
+  rule_type="text_contains", text="Accepted", match_type="exact",
+  background_color="#C8E6C9", text_color="#1B5E20")
+
+set_conditional_format(sheet="Pipeline", range="F4:F100",
+  rule_type="text_contains", text="Rejected", match_type="exact",
+  background_color="#FFCDD2", text_color="#B71C1C")
+```
+
+These do not need to be in a particular order — the conditions are mutually exclusive when `match_type: "exact"`. If two rules can match the same value, the lower index (`index: 0` is highest priority) wins; pass `index` explicitly when ordering matters.
+
+## Row-level highlighting from a category
+
+To highlight an entire row (not just the status cell) based on a categorical value, use `rule_type: "custom_formula"`:
+
+```python
+# Strike-through entire row when decision is in (accepted or rejected)
+set_conditional_format(
+  sheet="Pipeline",
+  range="A4:M100",  # all data columns
+  rule_type="custom_formula",
+  formula='=OR($F4="Accepted",$F4="Rejected")',
+  background_color="#FAFAFA",
+  text_color="#9E9E9E",
+  italic=True
+)
+```
+
+The `$F4` is row-relative (no `$` before the row number) so the rule walks down the data block correctly. The `$` before the column letter is required; omitting it makes the formula evaluate against each cell's column instead of the status column.

--- a/plugins/google-sheets-toolforest/references/themes.md
+++ b/plugins/google-sheets-toolforest/references/themes.md
@@ -1,0 +1,108 @@
+# Theme presets
+
+Like the Slides skill, four audience-mapped themes plus the default Toolforest brand. Apply via the formatting calls in `set_up_theme()` patterns shown for each.
+
+## Default — Toolforest Brand
+
+For internal tools, dashboards, anything not pitched at a specific audience.
+
+| Element | Value |
+|---|---|
+| Title banner bg | `#1F4E79` |
+| Title banner text | white Montserrat 16pt bold |
+| Section header bg | `#B8B8B8` |
+| Section header text | Montserrat 12pt bold (default color) |
+| Column header bg | `#4C4C4C` |
+| Column header text | white Source Sans 3 bold, centered |
+| Banding header | `#4C4C4C` |
+| Banding 1st band | `#FFFFFF` |
+| Banding 2nd band | `#F2F2F2` |
+| Body font | Source Sans 3 |
+| Mono font | IBM Plex Mono (for IDs, timestamps, code) |
+| Positive accent | `#2E7D32` |
+| Negative accent | `#B71C1C` |
+| Warning accent | `#F9A825` |
+| Info accent | `#1976D2` |
+
+## Boardroom — for financial/exec reports
+
+Heavier serif feel, restrained palette, formal.
+
+| Element | Value |
+|---|---|
+| Title banner bg | `#0D2137` (deep navy) |
+| Title banner text | cream `#F5F1E8`, Playfair Display 18pt bold |
+| Section header bg | `#E8E4D8` |
+| Section header text | Playfair Display 13pt |
+| Column header bg | `#0D2137` |
+| Column header text | cream, Lato bold, centered |
+| Banding bands | `#FFFFFF` / `#F8F5EE` |
+| Body font | Lato |
+| Mono font | Source Code Pro |
+| Accents | gold `#A47B3F`, sage `#5C6E5A` |
+
+Signature moves: roman-numeral row numbers in the leftmost column for executive summaries; right-aligned Lato bold for all currency totals; chapter-mark divider rows (single full-width merged cell) between sections.
+
+## Eng Scorecard — for evals, postmortems, latency reports
+
+Hyper-utilitarian, mono-heavy, contrast-led.
+
+| Element | Value |
+|---|---|
+| Title banner bg | `#1A1F2E` |
+| Title banner text | white IBM Plex Sans 14pt bold |
+| Section header bg | `#2E3440` |
+| Section header text | `#88C0D0`, IBM Plex Mono 11pt bold |
+| Column header bg | `#3B4252` |
+| Column header text | `#ECEFF4`, IBM Plex Mono bold |
+| Banding bands | `#FFFFFF` / `#ECEFF4` |
+| Body font | IBM Plex Sans |
+| Mono font | IBM Plex Mono (heavy use — IDs, durations, hashes) |
+| Accents | cyan `#5E81AC` (info), warm orange `#D08770` (warn), red `#BF616A` (fail), green `#A3BE8C` (pass) |
+
+Signature moves: status columns rendered as text (`PASS` / `FAIL` / `WARN`) in IBM Plex Mono, never icons; latency columns formatted `#,##0" ms"`; git-sha-style 7-char abbreviations in fixed-width columns.
+
+## Ops Tracker — for project management, task tracking
+
+Soft, approachable, color-led, dropdown-heavy.
+
+| Element | Value |
+|---|---|
+| Title banner bg | `#7B1FA2` |
+| Title banner text | white Source Sans 3 16pt bold |
+| Section header bg | `#E1BEE7` |
+| Column header bg | `#4A148C` |
+| Column header text | white Source Sans 3 bold |
+| Banding bands | `#FFFFFF` / `#F3E5F5` |
+| Body font | Source Sans 3 |
+| Status colors | `#C8E6C9`/`#1B5E20` (Done), `#FFE0B2`/`#E65100` (In Progress), `#FFCDD2`/`#B71C1C` (Blocked), `#E1F5FE`/`#01579B` (Backlog) |
+
+Signature moves: data validation dropdowns on every state column (status, priority, owner) backed by a `Reference` tab — easier to update lists than to hand-edit dropdowns; collapsible column groups for long-tail metadata (assignee, links, comments, history); filter views named for the questions they answer ("Blocked > 7 days", "Mine and due this week").
+
+## Marketing Rollup — for campaigns, growth dashboards
+
+Brighter, denser type hierarchy, chart-forward.
+
+| Element | Value |
+|---|---|
+| Title banner bg | gradient feel: solid `#FF6B35` |
+| Title banner text | white Oswald 18pt bold uppercase |
+| Section header bg | `#FFE0B2` |
+| Section header text | Oswald 12pt bold |
+| Column header bg | `#1A1A1A` |
+| Column header text | white Roboto bold, centered |
+| Banding bands | `#FFFFFF` / `#FFF8E1` |
+| Body font | Roboto |
+| Number font | Oswald (for big-stat cells) |
+| Accents | magenta `#E91E63`, yellow `#FFC107`, teal `#00ACC1` |
+
+Signature moves: oversized Oswald numbers (24–32pt) in dedicated single-row "scorecard" sections at the top; chart titles styled to match section headers; sparkline-in-row patterns for trend visibility without dedicated chart tabs.
+
+## Cross-theme rules
+
+These apply regardless of which theme you pick:
+
+1. **Apply banding before conditional formatting on the same range.** Banding paints the whole range; conditional formats paint over banding only on matched cells. Reverse order means the banding repaints over your highlights.
+2. **Two tones per accent.** A bright tone for use on dark backgrounds (column headers, dark banners) and a deep tone for use on light backgrounds (banded body cells). Single-tone accents fail WCAG body-text contrast on one of the two surfaces.
+3. **Min font size in tight columns.** Sheets autofit shrinks freely. If a column is narrow and content is long, fix the column width via `set_column_width` rather than relying on autofit — there's no `min_font_size_pt` in Sheets.
+4. **No mono fonts for prose, no proportional fonts for IDs.** Sticking to this consistently is what makes a sheet look like infrastructure rather than a document.

--- a/plugins/google-sheets-toolforest/references/worked_example_financial_dashboard.md
+++ b/plugins/google-sheets-toolforest/references/worked_example_financial_dashboard.md
@@ -1,0 +1,97 @@
+# Worked example: multi-tab financial dashboard
+
+End-to-end build for a multi-venue funding-rate arbitrage monitor. Four tabs, named-range cross-references, formula-driven dashboards, conditional formatting, charts, error verification. This example was used to verify every pattern in `SKILL.md` and produces a sheet that resolves with zero formula errors.
+
+## Specification
+
+- **Spreadsheet title:** "Funding Rate Arb Monitor"
+- **Tabs:** `Live Dashboard`, `Funding Rates` (raw), `Positions` (raw), `Charts` (computed pivots + visualizations)
+- **Source data:** 8h funding rates across 4 venues (Binance, Bybit, OKX, Hyperliquid) × 5 assets (BTC, ETH, SOL, ARB, AVAX) × 6 recent timestamps = 120 rows
+- **Computed:** latest rate matrix per (asset, venue), median rate per asset, best long/short venue per asset, annualized spread in bps, mark-to-funding PnL per open position
+
+## Build sequence
+
+The full sequence (12 distinct stages) lives in this skill's parent test runs. The skeleton:
+
+1. `create_spreadsheet` → delete default `Sheet1` (sheet_id: 0)
+2. `create_sheet` × 4 with tab colors (Live Dashboard pink, Funding Rates blue, Positions green, Charts purple)
+3. Push raw funding data with `update_values` (120 rows)
+4. Push positions with `update_values` (4 rows)
+5. `batch_add_named_range` for `FundingData`, `PositionsData`, `AssetsList`, `VenuesList`
+6. `batch_update_values` for the dashboard formula matrix (5 assets × 4 venues + median/best-long/best-short/spread columns)
+7. `fill_formula` × 3 for venue columns of the rate matrix (one per venue, since `fill_formula` is single-axis)
+8. `freeze_panes` (5 rows, 0 columns — see SKILL.md pattern #7)
+9. `batch_format_cells` for title, headers, number formats
+10. `merge_cells` for title banner
+11. `set_conditional_format` × 4 (color scale on rate matrix, threshold on spread, green/red on PnL)
+12. Charts: pivot helper tables on Charts tab (`batch_update_values`), then `batch_create_chart` (5 line charts, camelCase keys)
+13. `auto_resize_columns` with `max_width_px: 240` to guard against the merged-banner inflation
+14. `check_spreadsheet_errors` with `detect_circular_refs: true` — must return zero
+
+## Key formulas
+
+Latest annualized funding rate for (asset, venue) from the long source table:
+
+```
+=IFERROR(INDEX(FundingData,
+  MATCH(1,
+    (INDEX(FundingData,,1)=MAX(IF(INDEX(FundingData,,2)=B$5,
+      IF(INDEX(FundingData,,3)=$A6,
+        INDEX(FundingData,,1)))))
+    * (INDEX(FundingData,,2)=B$5)
+    * (INDEX(FundingData,,3)=$A6),
+    0),
+  5))
+```
+
+The `MAX(IF(...))` finds the latest timestamp for that (asset, venue) pair; the outer `MATCH(1, (...)*(...)*(...))` finds the row matching all three keys. Wrapped in `IFERROR` so missing combinations return blank rather than `#N/A`.
+
+Best long venue (lowest rate among 4):
+
+```
+=INDEX($B$5:$E$5, MATCH(MIN(B6:E6), B6:E6, 0))
+```
+
+Annualized spread in bps:
+
+```
+=(MAX(B6:E6) - MIN(B6:E6)) * 100
+```
+
+(Source data is already annualized as percentage, so multiplying the difference by 100 converts pct-points to bps.)
+
+Position PnL accrual:
+
+```
+=Notional * EntryDiff * 3 * DaysOpen
+```
+
+Where `EntryDiff` is the per-8h funding rate diff at entry, `3` is fundings/day, `DaysOpen` from `DATEDIF` against today. For mark-to-funding PnL, replace `EntryDiff` with `CurrentDiff` looked up via `INDEX/MATCH` against the latest rate matrix.
+
+## Number formats used
+
+| Range | Format | Why |
+|---|---|---|
+| Annualized rate cells | `0.00"%"` (NUMBER) | Source data is already in pct units (12.0860 = 12.0860%); PERCENT format would multiply ×100 again → 1208.60% |
+| Notional/PnL | `$#,##0` (CURRENCY) | Standard |
+| 8h funding rate (raw) | `0.0000000` (NUMBER) | 7 decimal places — funding rates are 1e-4 to 1e-3 typical |
+| Spread (bps) | `#,##0` (NUMBER) | Integer bps |
+| Days Open | (default, centered) | Just an integer |
+
+The percent-format trap is the most common misstep. PERCENT type is for fractions (0.025 → 2.5%); use `0.00"%"` NUMBER pattern for already-multiplied values.
+
+## Verification
+
+After the full build, `check_spreadsheet_errors` must return:
+
+```
+{ "total_errors": 0, "total_warnings": 0, "error_counts": {}, "sheets_affected": [] }
+```
+
+If it returns a `#REF!` count > 0, the most likely cause is one of:
+
+- Named range references a sheet that's been renamed or deleted
+- `INDIRECT` formula not single-quoting a hyphenated sheet name
+- A `MATCH` lookup against a column that's empty or contains the wrong dtype
+
+Spot-check `formulaResults` from the Live Dashboard build response to confirm the rate matrix populated with realistic values (single-digit to low-double-digit annualized %, not zeros or very large numbers indicating a unit mismatch).


### PR DESCRIPTION
## Summary
- Adds a new `google-sheets-toolforest` plugin to the Skills Marketplace, parallel in structure to `google-slides-toolforest`.
- Ships `SKILL.md` + 4 reference files: `batch_wrappers.md`, `categorical_formatting.md`, `themes.md`, `worked_example_financial_dashboard.md`.
- Registers the plugin in `.claude-plugin/marketplace.json` and adds a section to `README.md`.

Content is verbatim from the five comments on toolforest_tools#1324, with YAML frontmatter on `SKILL.md` to mirror the Slides skill's registration mechanism (so the skill auto-loads on `google_sheets-*` tool calls).

Closes Toolforest-io/toolforest_tools#1324.

## Test plan
- [ ] `/plugin marketplace add toolforest-io/toolforest-skills-marketplace` resolves the new plugin
- [ ] `/plugin install google-sheets-toolforest@toolforest-skills` succeeds
- [ ] Skill auto-loads on a `google_sheets-create_spreadsheet` call and surfaces the documented patterns
- [ ] All four reference files are reachable from `SKILL.md`'s relative links
- [ ] No "Mercury" or personal references anywhere in the new files (verified `grep` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)