### PR TITLE
fix(google-slides): snake_case create_chart args in Sheets-chart workflow doc

### DIFF
--- a/plugins/google-slides-toolforest/references/images-and-charts.md
+++ b/plugins/google-slides-toolforest/references/images-and-charts.md
@@ -29,11 +29,11 @@ For any chart or data visualization, always use Google Sheets → Google Slides 
 ### Sheets Chart Workflow
 Step 1: create_spreadsheet → returns spreadsheet_id
 Step 2: update_values with headers in row 1, data below
-Step 3: create_chart with chartType, sourceRange, title, seriesColors matching the deck’s theme
+Step 3: create_chart with chart_type, source_range, title, series_colors matching the deck’s theme
 Step 4: embed_chart with linking_mode: "LINKED" (live data) or "NOT_LINKED_IMAGE" (static snapshot)
 ### Chart Styling Tips
-- Use seriesColors to match the presentation’s color palette from config.json
-- Set legendPosition: "none" for single-series charts
+- Use series_colors to match the presentation’s color palette from config.json
+- Set legend_position: "none" for single-series charts
 - Control aspect ratio via width/height in create_chart; control slide size via EMU in embed_chart
 
 ### Why Not Matplotlib?


### PR DESCRIPTION
## Summary

\`plugins/google-slides-toolforest/references/images-and-charts.md\` referenced google_sheets \`create_chart\` arguments using camelCase, but the deployed Pydantic schema is snake_case. An LLM reading this guide and constructing a tool call from its prose hints would get a Pydantic validation error.

## Changes

| Old | New |
|---|---|
| \`chartType\` | \`chart_type\` |
| \`sourceRange\` | \`source_range\` |
| \`seriesColors\` | \`series_colors\` |
| \`legendPosition\` | \`legend_position\` |

3 lines: 32, 35, 36.

## Why this is the right direction

Verified against the live dev-MCP schema for \`google_sheets-create_chart\` (via the toolforest-router \`get_tool_schemas\`):

\`\`\`json
{
  \"properties\": {
    \"spreadsheet_id\": {...},
    \"sheet\": {...},
    \"source_range\": {...},
    \"chart_type\": {...},
    \"series_colors\": {...},
    \"legend_position\": {...},
    ...
  }
}
\`\`\`

## Why \`batch_create_chart\` is *not* affected

The other chart wrapper \`batch_create_chart\` accepts camelCase inner-dict keys (the array element schema is \`Dict[str, Any]\` whose keys passthrough to the Google API). That convention is documented separately and correctly in \`google-sheets-toolforest/references/batch_wrappers.md\` (with explicit WRONG/RIGHT pedagogy showing snake_case fails at that level). No change needed there.

## Detection

Found via a dev-MCP audit pass after the toolforest_tools case-style cleansweep (PRs Toolforest-io/toolforest_tools#1429, #1430, #1434). A haiku subagent grepped each marketplace skill's prose for tool-arg examples and compared each arg key against the live \`get_tool_schemas\` response.

## Test plan
- [ ] Manual: in Claude Code with the google-slides-toolforest skill enabled, trigger the Sheets-chart workflow and verify the LLM uses snake_case args (no Pydantic error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)