### PR TITLE
feat(google-slides): horizontal overflow + outline_visible verification guidance

### DIFF
--- a/plugins/google-slides-toolforest/.claude-plugin/plugin.json
+++ b/plugins/google-slides-toolforest/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google-slides-toolforest",
   "description": "Best practices for building Google Slides decks via Toolforest MCP. Theme presets (Midnight Editorial, Sunset Terracotta, Arctic Mono, Tokyo Neon), font and chart pipelines, image encoding gotchas, and slide verification checklists — all derived from end-to-end builds verified to render cleanly.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Toolforest (toolforest.io)"
   },

--- a/plugins/google-slides-toolforest/SKILL.md
+++ b/plugins/google-slides-toolforest/SKILL.md
@@ -34,10 +34,15 @@ After calling get_slide_content_elements, check ALL of the following. If ANY che
 - ≥ 150,000 EMU gap between elements (228,600 EMU preferred)
 - Stacked text is measure-then-place: never anchor subtitles, captions, or body text below a variable-height headline using a hardcoded `y`. Verify the upper text box first, then place the lower element at `actual_bottom + gap`, where `actual_bottom = y + max(height, estimatedContentHeight)`.
 
-**Text overflow:**
+**Text overflow (vertical):**
 - estimatedOverflow: false on all text boxes and tables
 - For text boxes, investigate overflow by comparing `estimatedContentHeight` to `estimatedUsableHeight` (not raw element height). Google Slides reserves internal vertical text inset, and `estimatedOverflow` uses the usable height.
 - If autofit was used: scale_factor ≥ 0.7. If below 0.7, the element MUST be rebuilt — enlarge the box, reduce content, or split across elements.
+
+**Text overflow (horizontal):**
+- `estimatedHorizontalOverflow: false` on all text boxes. `true` means content bleeds past the box's left/right edges — the vertical checks above cannot detect this.
+- Investigate by comparing `estimatedContentWidth` (widest rendered line) to `estimatedUsableWidth` (box width minus the horizontal inset). Normally-wrapping text never trips this; it fires for unbreakable content wider than the box — oversized drop-cap glyphs, big display numerals, or a forced single line.
+- To fix: widen the box so `estimatedContentWidth ≤ estimatedUsableWidth`. A decorative glyph may legitimately overflow *vertically* (tall by nature), but `estimatedHorizontalOverflow: true` is a real bleed — fix it.
 
 **Font sizes (tiered minimum):**
 - Body text, bullets, descriptions: ≥ 14pt
@@ -72,7 +77,7 @@ Always set autofit: true + min_font_size_pt: 10 on content text boxes. Check sca
 Two corollaries that bite repeatedly:
 
 - **Pass `min_font_size_pt: 10` on every body text box that might not fit its content** (especially in tight cards). Without the explicit floor, autofit will silently scale below 10pt and violate the hard rule above.
-- **Decorative oversized glyphs need `autofit: false`.** Drop-cap quote marks, big italic numerals, condensed display type at 96pt+ — autofit will scale them below the 0.7 floor every time. Use `autofit: false` and a generously sized box. If a genuinely decorative glyph reports `estimatedOverflow: true`, compare `estimatedContentHeight` with `estimatedUsableHeight` and use visual verification before overriding the warning. Never override body text overflow.
+- **Decorative oversized glyphs need `autofit: false`.** Drop-cap quote marks, big italic numerals, condensed display type at 96pt+ — autofit will scale them below the 0.7 floor every time. Use `autofit: false` and a generously sized box. A genuinely decorative glyph may report `estimatedOverflow: true` simply because it is tall (compare `estimatedContentHeight` with `estimatedUsableHeight`) — that vertical warning can be acceptable. But `estimatedHorizontalOverflow: true` means the glyph is bleeding sideways out of its box: the box is too narrow — widen it until `estimatedContentWidth ≤ estimatedUsableWidth`. Never override body text overflow of either kind.
 
 ### Gotcha 2: Hex Encoding for Images, Never Base64
 

--- a/plugins/google-slides-toolforest/references/tables-and-formatting.md
+++ b/plugins/google-slides-toolforest/references/tables-and-formatting.md
@@ -4,6 +4,7 @@ Read this file when creating tables or text-heavy slides. The multi-run techniqu
 - alternate_row_color adds automatic row striping
 - Set autofit: true to automatically shrink header and body font sizes to fit within the specified table height (assumes Arial metrics). Set min_font_size_pt: 10 to control the floor. Check autofitApplied and scale_factor in the response — values below 0.7 mean the table is too dense for the space and MUST be rebuilt (enlarge the table, reduce content, or split across slides).
 - get_slide_content_elements returns estimatedContentHeight and estimatedOverflow for tables, plus an autofit field showing whether autofit was applied and the scale factor used
+- For text boxes (not tables), get_slide_content_elements also returns estimatedContentWidth / estimatedUsableWidth / estimatedHorizontalOverflow to catch horizontal bleed (e.g. oversized drop-cap glyphs), and outline_visible to catch a stray border
 
 ## Multi-Run Text Formatting — The Key to Visual Hierarchy
 The add_text_box tool supports multiple runs per paragraph, each with independent font size, color, bold/italic, and font family. Always use this to create proper hierarchy. Never default to a single font size and color for an entire text box.

--- a/plugins/google-slides-toolforest/references/themes.md
+++ b/plugins/google-slides-toolforest/references/themes.md
@@ -25,7 +25,7 @@ Without the explicit floor, autofit will silently scale below 10pt and violate t
 
 ### 3. Decorative oversized glyphs need `autofit: false`
 
-Drop-cap quote marks, big italic numerals, condensed display type at 96pt+ — autofit will scale them below the 0.7 floor every time. Use `autofit: false` and a generously sized box. If a genuinely decorative glyph reports `estimatedOverflow: true`, compare `estimatedContentHeight` with `estimatedUsableHeight` and use visual verification before overriding the warning. Never override body text overflow.
+Drop-cap quote marks, big italic numerals, condensed display type at 96pt+ — autofit will scale them below the 0.7 floor every time. Use `autofit: false` and a generously sized box. A genuinely decorative glyph may report `estimatedOverflow: true` just because it is tall (compare `estimatedContentHeight` with `estimatedUsableHeight`) — that vertical warning can be acceptable. But `estimatedHorizontalOverflow: true` means the glyph is bleeding sideways out of a too-narrow box: widen it until `estimatedContentWidth ≤ estimatedUsableWidth`. Never override body text overflow of either kind.
 
 ### 4. The same-font-heading-body rule has one exception
 

--- a/plugins/google-slides-toolforest/scripts/verify_slide.md
+++ b/plugins/google-slides-toolforest/scripts/verify_slide.md
@@ -7,10 +7,14 @@ Run this checklist after building EVERY slide. Call get_slide_content_elements a
 - Variable stacked text: For text placed below a headline, title, stat, or any other variable-height text box, compute the upper box's occupied bottom as `y + max(height, estimatedContentHeight)`. The lower element must start after that bottom plus the required gap. A fixed `y` for subtitles or captions is a failure if the upper text's measured content height changes.
 
 ## Text and Table Overflow Checks
-- Check estimatedOverflow: false on all text boxes and tables.
+- Check estimatedOverflow: false on all text boxes and tables (vertical overflow).
 - For text boxes, compare estimatedContentHeight to estimatedUsableHeight. Do not compare against raw element height; Google Slides reserves internal vertical text inset.
+- Check estimatedHorizontalOverflow: false on all text boxes (horizontal bleed past the left/right edges — the vertical checks cannot detect this). Compare estimatedContentWidth (widest rendered line) to estimatedUsableWidth (box width minus the horizontal inset). It fires only for unbreakable content wider than the box (oversized drop-cap glyphs, big numerals); normally-wrapping text never trips it. Fix by widening the box. A decorative glyph may overflow vertically yet must not overflow horizontally.
 - For tables, compare estimatedContentHeight to the element's actual height.
 - If autofit was used (text boxes or tables), check scale_factor — values below 0.7 mean the element is too small for the content. **This is a hard failure: delete and rebuild the element** (enlarge the box, reduce content, or split across elements).
+
+## Outline (border) Check
+- get_slide_content_elements returns outline_visible on shapes and text boxes: true (border renders), false (hidden), or null (inherited from theme). If a text box was meant to be borderless but reports outline_visible: true, hide it with update_element_style (outline_visible: false).
 
 ## Contrast Checks (from get_slide_content_elements)
 - Text elements include `contrastRatio` (float) and `contrastSufficient` (boolean) when a background color is available


### PR DESCRIPTION
`get_slide_content_elements` now returns horizontal-overflow fields (`estimatedContentWidth` / `estimatedUsableWidth` / `estimatedHorizontalOverflow`) and `outline_visible`, shipped to prod in toolforest_tools #1541. This updates the skill guidance to use them.

## Changes
- **SKILL.md**: split overflow checks into vertical + horizontal. Replaced the fuzzy "use visual verification before overriding" decorative-glyph guidance with a concrete rule — a decorative glyph may overflow *vertically* (tall by nature), but `estimatedHorizontalOverflow: true` is a real sideways bleed → widen the box until `estimatedContentWidth ≤ estimatedUsableWidth`.
- **scripts/verify_slide.md**: added horizontal-overflow check + an outline (border) check.
- **references/themes.md**, **references/tables-and-formatting.md**: same horizontal-overflow rule + field summary.
- Plugin version 1.0.0 → 1.1.0.

## Why now
These fields are live in **prod** (verified on dev + test via the toolforest-router; the isolating "drop-cap" case reports vertical `false` / horizontal `true`). The skill drives the prod MCP endpoint, so the guidance is safe to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)